### PR TITLE
Object#timeout is deprecated, use Timeout.timeout instead

### DIFF
--- a/bin/check-sensor.rb
+++ b/bin/check-sensor.rb
@@ -93,7 +93,7 @@ class CheckSensor < Sensu::Plugin::Metric::CLI::Graphite
          default: 30
 
   def conn
-    timeout(config[:timeout].to_i) do
+    Timeout.timeout(config[:timeout].to_i) do
       Rubyipmi.connect(config[:username],
                        config[:password],
                        config[:host],


### PR DESCRIPTION
Fixes #3.

We have it running in production here.