### PR TITLE
add support for specifying the driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- The underlying rubyipmi gem supports setting the driver used for the connection so we expose that via the `---driver` argument (@peterhoeg)
+- Updated the README with possible fixes when talking to older (< v2) IPMI hosts (@peterhoeg)
 
 ## [1.0.1] - 2017-08-07
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 ## Functionality
 
+By default when using `ipmitool` to connect, we default to using the `lan20` driver for IPMI v2 hosts which will not work with older (IPMI v1.5+) hosts. Instead of specifying the driver for each host, you can try setting it to `auto`.
+
 ## Files
  * bin/check-sensor.rb
 

--- a/bin/check-sensor.rb
+++ b/bin/check-sensor.rb
@@ -84,13 +84,15 @@ class CheckSensor < Sensu::Plugin::Metric::CLI::Graphite
          description: 'IPMI Tool Provider (ipmitool OR freeipmi).  Default is ipmitool.',
          short: '-i IPMI_PROVIDER',
          long: '--ipmitool IPMI_PROVIDER',
-         default: 'ipmitool'
+         default: 'ipmitool',
+         in: %w(freeipmi ipmitool)
 
   option :driver,
          description: 'IPMI Tool Driver: auto, lan15, lan20, open (defaults to lan20)',
          short: '-d IPMI_DRIVER',
          long: '--driver IPMI_DRIVER',
-         default: 'lan20'
+         default: 'lan20',
+         in: %w(auto lan15 lan20 open)
 
   option :timeout,
          description: 'IPMI connection timeout in seconds (defaults to 30)',

--- a/bin/check-sensor.rb
+++ b/bin/check-sensor.rb
@@ -86,6 +86,12 @@ class CheckSensor < Sensu::Plugin::Metric::CLI::Graphite
          long: '--ipmitool IPMI_PROVIDER',
          default: 'ipmitool'
 
+  option :driver,
+         description: 'IPMI Tool Driver: auto, lan15, lan20, open (defaults to lan20)',
+         short: '-d IPMI_DRIVER',
+         long: '--driver IPMI_DRIVER',
+         default: 'lan20'
+
   option :timeout,
          description: 'IPMI connection timeout in seconds (defaults to 30)',
          short: '-t TIMEOUT',
@@ -98,6 +104,7 @@ class CheckSensor < Sensu::Plugin::Metric::CLI::Graphite
                        config[:password],
                        config[:host],
                        config[:provider],
+                       driver: config[:driver],
                        privilege: config[:privilege])
     end
   rescue Timeout::Error


### PR DESCRIPTION
## Pull Request Checklist

ipmitool supports setting the driver which for reasons unknown defaults to lan20 (ipmi v2) which makes this plugin fail on older IPMI versions.

This PR adds support for setting the driver.

We could also consider if we should change the default from ```lan20``` to ```auto``` as that seems to automatically work on both IPMI v1.5 and 2.0.

Any comments? I'll update the README as well - I just wanted to get this out there quickly first (we have it running in production as of a few minutes ago).

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatability Issues

